### PR TITLE
Added ability for 'after-skip' to be set to negative values.

### DIFF
--- a/tasks.sty
+++ b/tasks.sty
@@ -652,6 +652,7 @@
     \int_incr:N \l__tasks_depth_int
     \__tasks:VnnV \l__tasks_instance_tl { #3 } { #1 } \BODY
     \endlist
+    \skip_vertical:N \c_zero_skip
     \skip_vertical:N \l__tasks_after_list_skip
   }
 


### PR DESCRIPTION
Hi,
I needed to set the 'before-skip' and 'after-skip' spacing to negative values so that I could have really tight packed lists/tasks.
Negative values for 'before-skip' worked just fine, but not so much for 'after-skip'.
After some trial & error I came up with this little addition.
A good solution or will this lead to some problems down the road? (I'm not a TeX guru)
