### PR TITLE
Revert "Added ability for 'after-skip' to be set to negative values."

### DIFF
--- a/tasks.sty
+++ b/tasks.sty
@@ -652,7 +652,6 @@
     \int_incr:N \l__tasks_depth_int
     \__tasks:VnnV \l__tasks_instance_tl { #3 } { #1 } \BODY
     \endlist
-    \skip_vertical:N \c_zero_skip
     \skip_vertical:N \l__tasks_after_list_skip
   }
 


### PR DESCRIPTION
Oh God, this is a bit embarrassing....
I've just noticed that I've added the `\skip_vertical:N \c_zero_skip` line above instead of below.
Revert this. I'll submit the proper one.
