### PR TITLE
Update default value of `label-width` in docs

### DIFF
--- a/tasks-manual.tex
+++ b/tasks-manual.tex
@@ -239,7 +239,7 @@ following ones that can be set using a setup command:
     \sinceversion{1.3}Works like \option{label} but sets the output of the
     reference by setting \cs*{the\meta{counter}} (\cs{thetask} in the default
     setting).
-  \keyval{label-width}{dim}\Default{1em}
+  \keyval{label-width}{dim}\Default{11pt}
     Sets the width of the item labels.
   \keyval{label-offset}{dim}\Default{.3333em}
     \sinceversion{0.7}Sets the offset, \ie, the distance between label and
@@ -500,7 +500,7 @@ of their usage.
       label           : tokenlist = \alph*) ,
       indent          : length    = 2.5em   ,
       label-format    : tokenlist           ,
-      label-width     : length    = 1em     ,
+      label-width     : length    = 11pt    ,
       label-offset    : length    = .3333em ,
       after-item-skip : skip      = \itemsep
     }


### PR DESCRIPTION
a47c119 (add warning messages regarding with of labels and indent,2019-10-04) changed the default value of `label-indent` from 1em to 11pt.